### PR TITLE
fix read the docs config to support poetry as dependency manager, upd…

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,4 +15,5 @@ formats: all
 python:
   version: 3.6
   install:
-    - requirements: requirements.txt
+    - method: pip
+      path: .

--- a/docs/sdk/configuration/device.md
+++ b/docs/sdk/configuration/device.md
@@ -104,9 +104,10 @@ restrictions on the values.
 | ***type*** | int |
 | ***key*** | `version` |
 
-```YAML tab=
-version: 3
-```
+=== "YAML"
+    ```yaml
+    version: 3
+    ```
 
 -----
 
@@ -118,10 +119,11 @@ version: 3
 | ***type*** | list[[Device Prototype](#device-prototype)] |
 | ***key*** | `devices` |
 
-```YAML tab=
-devices:
-- <device prototype>
-```
+=== "YAML"
+    ```yaml
+    devices:
+    - <device prototype>
+    ```
 
 -----
 
@@ -138,12 +140,13 @@ A device prototype defines the high-level information which applies to a class o
 | ***type*** | string |
 | ***key*** | `type` |
 
-```YAML tab=
-version: 3
-devices:
--
-  type: temperature
-```
+=== "YAML"
+    ```yaml
+    version: 3
+    devices:
+    -
+      type: temperature
+    ```
 
 #### Context
 
@@ -156,15 +159,16 @@ devices:
 Values in the context may also include templates. Currently, the templates only support the `env` function to
 get a value from environment.
 
-```YAML tab=
-version: 3
-devices:
--
-  context:
-    manufacturer: vapor
-    part_number: 123
-    host: {{ env "NODE_NAME" }}
-```
+=== "YAML"
+    ```yaml
+    version: 3
+    devices:
+    -
+      context:
+        manufacturer: vapor
+        part_number: 123
+        host: {{ env "NODE_NAME" }}
+    ```
 
 #### Tags
 
@@ -177,15 +181,16 @@ devices:
 Tags definitions may also include templates. Currently, the tag templates only support the `env` function
 to get a value from environment.
 
-```YAML tab=
-version: 3
-devices:
--
-  tags:
-  - synse/tag1
-  - synse/tag2
-  - rack/{{ env "NODE_NAME" }}
-```
+=== "YAML"
+    ```yaml
+    version: 3
+    devices:
+    -
+      tags:
+      - synse/tag1
+      - synse/tag2
+      - rack/{{ env "NODE_NAME" }}
+    ```
 
 #### Data
 
@@ -195,15 +200,16 @@ devices:
 | ***type*** | map[string]Any |
 | ***key*** | `data` |
 
-```YAML tab=
-version: 3
-devices:
--
-  data:
-    address: localhost:5432
-    port: 3000
-    timeout: 10
-```
+=== "YAML"
+    ```yaml
+    version: 3
+    devices:
+    -
+      data:
+        address: localhost:5432
+        port: 3000
+        timeout: 10
+    ```
 
 #### Handler
 
@@ -213,12 +219,13 @@ devices:
 | ***type*** | string |
 | ***key*** | `handler` |
 
-```YAML tab=
-version: 3
-devices:
--
-  handler: temperature
-```
+=== "YAML"
+    ```yaml
+    version: 3
+    devices:
+    -
+      handler: temperature
+    ```
 
 #### Write Timeout
 
@@ -230,12 +237,13 @@ devices:
 | ***default*** | `30s` |
 | ***supported*** | [duration](https://golang.org/pkg/time/#example_Duration) strings |
 
-```YAML tab=
-version: 3
-devices:
--
-  writeTimeout: 20s
-```
+=== "YAML"
+    ```yaml
+    version: 3
+    devices:
+    -
+      writeTimeout: 20s
+    ```
 
 #### Transforms
 
@@ -257,14 +265,15 @@ they are applied.
 > **Note**: If a device instance also defines `transforms` and inheritance is enabled, the two lists will be
 > joined with their order preserved and the items in the prototype definition coming first.
 
-```YAML tab=
-version: 3
-devices:
--
-  transforms:
-  - scale: "0.1"
-  - apply: "FtoC"
-```
+=== "YAML"
+    ```yaml
+    version: 3
+    devices:
+    -
+      transforms:
+      - scale: "0.1"
+      - apply: "FtoC"
+    ```
 
 #### Instances
 
@@ -274,13 +283,14 @@ devices:
 | ***type*** | list[[device instance](#device-instance)] |
 | ***key*** | `instances` |
 
-```YAML tab=
-version: 3
-devices:
--
-  instances:
-  - <device instance>
-```
+=== "YAML"
+    ```yaml
+    version: 3
+    devices:
+    -
+      instances:
+      - <device instance>
+    ```
 
 -----
 
@@ -294,13 +304,14 @@ devices:
 | ***type*** | string |
 | ***key*** | `type` |
 
-```YAML tab=
-version: 3
-devices:
--
-  instances:
-  - type: temperature
-```
+=== "YAML"
+    ```yaml
+    version: 3
+    devices:
+    -
+      instances:
+      - type: temperature
+    ```
 
 #### Info
 
@@ -310,13 +321,14 @@ devices:
 | ***type*** | string |
 | ***key*** | `info` |
 
-```YAML tab=
-version: 3
-devices:
--
-  instances:
-  - info: Top of rack front temperature sensor
-```
+=== "YAML"
+    ```yaml
+    version: 3
+    devices:
+    -
+      instances:
+      - info: Top of rack front temperature sensor
+    ```
 
 #### Context
 
@@ -329,16 +341,17 @@ devices:
 Values in the context may also include templates. Currently, the templates only support the `env` function to
 get a value from environment.
 
-```YAML tab=
-version: 3
-devices:
--
-  instances:
-  - context:
-      model: abc123
-      position: rear
-      rack: {{ env "NODE_NAME" }}
-```
+=== "YAML"
+    ```yaml
+    version: 3
+    devices:
+    -
+      instances:
+      - context:
+          model: abc123
+          position: rear
+          rack: {{ env "NODE_NAME" }}
+    ```
 
 #### Tags
 
@@ -351,16 +364,17 @@ devices:
 Tags definitions may also include templates. Currently, the tag templates only support the `env` function
 to get a value from environment.
 
-```YAML tab=
-version: 3
-devices:
--
-  instances:
-  - tags:
-    - synse/tag1
-    - synse/tag2
-    - rack/{{ env "NODE_NAME" }}
-```
+=== "YAML"
+    ```yaml
+    version: 3
+    devices:
+    -
+      instances:
+      - tags:
+        - synse/tag1
+        - synse/tag2
+        - rack/{{ env "NODE_NAME" }}
+    ```
 
 #### Data
 
@@ -370,16 +384,17 @@ devices:
 | ***type*** | map[string]Any |
 | ***key*** | `data` |
 
-```YAML tab=
-version: 3
-devices:
--
-  instances:
-  - data:
-      address: /dev/ttyUSB0
-      baud: 9600
-      parity: e
-```
+=== "YAML"
+    ```yaml
+    version: 3
+    devices:
+    -
+      instances:
+      - data:
+          address: /dev/ttyUSB0
+          baud: 9600
+          parity: e
+    ```
 
 #### Output
 
@@ -389,13 +404,14 @@ devices:
 | ***type*** | string |
 | ***key*** | `output` |
 
-```YAML tab=
-version: 3
-devices:
--
-  instances:
-  - output: temperature
-```
+=== "YAML"
+    ```yaml
+    version: 3
+    devices:
+    -
+      instances:
+      - output: temperature
+    ```
 
 #### Sort Index
 
@@ -406,13 +422,14 @@ devices:
 | ***key*** | `sortIndex` |
 | ***default*** | `0` |
 
-```YAML tab=
-version: 3
-devices:
--
-  instances:
-  - sortIndex: 2
-```
+=== "YAML"
+    ```yaml
+    version: 3
+    devices:
+    -
+      instances:
+      - sortIndex: 2
+    ```
 
 #### Handler
 
@@ -422,13 +439,14 @@ devices:
 | ***type*** | string |
 | ***key*** | `handler` |
 
-```YAML tab=
-version: 3
-devices:
--
-  instances:
-  - handler: temperature
-```
+=== "YAML"
+    ```yaml
+    version: 3
+    devices:
+    -
+      instances:
+      - handler: temperature
+    ```
 
 #### Alias
 
@@ -442,14 +460,15 @@ An [alias](../concepts/device_aliases.md) which can be used to reference the dev
 | ***type*** | string |
 | ***key*** | `name` |
 
-```YAML tab=
-version: 3
-devices:
--
-  instances:
-  - alias:
-      name: front-temperature
-```
+=== "YAML"
+    ```yaml
+    version: 3
+    devices:
+    -
+      instances:
+      - alias:
+          name: front-temperature
+    ```
 
 ***Template***
 
@@ -459,14 +478,15 @@ devices:
 | ***type*** | string |
 | ***key*** | `template` |
 
-```YAML tab=
-version: 3
-devices:
--
-  instances:
-  - alias:
-      template: "{{ .Device.Type }}-{{ ctx port }}"
-```
+=== "YAML"
+    ```yaml
+    version: 3
+    devices:
+    -
+      instances:
+      - alias:
+          template: "{{ .Device.Type }}-{{ ctx port }}"
+    ```
 
 #### Transforms
 
@@ -488,15 +508,16 @@ they are applied.
 > **Note**: If a device prototype also defines `transforms` and inheritance is enabled, the two lists will be
 > joined with their order preserved and the items in the prototype definition coming first.
 
-```YAML tab=
-version: 3
-devices:
--
-  instances:
-  - transforms:
-    - scale: "0.1"
-    - apply: "FtoC"
-```
+=== "YAML"
+    ```yaml
+    version: 3
+    devices:
+    -
+      instances:
+      - transforms:
+        - scale: "0.1"
+        - apply: "FtoC"
+    ```
 
 #### Write Timeout
 
@@ -508,13 +529,14 @@ devices:
 | ***default*** | `30s` |
 | ***supported*** | [duration](https://golang.org/pkg/time/#example_Duration) strings |
 
-```YAML tab=
-version: 3
-devices:
--
-  instances:
-  - writeTimeout: 20s
-```
+=== "YAML"
+    ```yaml
+    version: 3
+    devices:
+    -
+      instances:
+      - writeTimeout: 20s
+    ```
 
 #### Disable Inheritance
 
@@ -526,13 +548,14 @@ devices:
 | ***default*** | `false` |
 | ***supported*** | `true`, `false` |
 
-```YAML tab=
-version: 3
-devices:
--
-  instances:
-  - disableInheritance: true
-```
+=== "YAML"
+    ```yaml
+    version: 3
+    devices:
+    -
+      instances:
+      - disableInheritance: true
+    ```
 
 ## Example
 

--- a/docs/sdk/configuration/plugin.md
+++ b/docs/sdk/configuration/plugin.md
@@ -105,9 +105,10 @@ restrictions on the values and any defaults.
 | ***type*** | int |
 | ***key*** | `version` |
 
-```YAML tab=
-version: 3
-```
+=== "YAML"
+    ```yaml
+    version: 3
+    ```
 
 -----
 
@@ -121,9 +122,10 @@ version: 3
 | ***default*** | `false` |
 | ***supported*** | `true`, `false` |
 
-```YAML tab=
-debug: true
-```
+=== "YAML"
+    ```yaml
+    debug: true
+    ```
 
 -----
 
@@ -143,10 +145,11 @@ Group key: `id`
 | ***default*** | `false` |
 | ***supported*** | `true`, `false` |
 
-```YAML tab=
-id:
-  useMachineID: true
-```
+=== "YAML"
+    ```yaml
+    id:
+      useMachineID: true
+    ```
 
 #### Use Plugin Tag
 
@@ -158,10 +161,11 @@ id:
 | ***default*** | `true` |
 | ***supported*** | `true`, `false` |
 
-```YAML tab=
-id:
-  usePluginTag: true
-```
+=== "YAML"
+    ```yaml
+    id:
+      usePluginTag: true
+    ```
 
 #### Use Env
 
@@ -172,12 +176,13 @@ id:
 | ***key*** | `useEnv` |
 | ***default*** | `[]` |
 
-```YAML tab=
-id:
-  useEnv:
-  - ENV_1
-  - ENV_2
-```
+=== "YAML"
+    ```yaml
+    id:
+      useEnv:
+      - ENV_1
+      - ENV_2
+    ```
 
 #### Use Custom
 
@@ -188,12 +193,13 @@ id:
 | ***key*** | `useCustom` |
 | ***default*** | `[]` |
 
-```YAML tab=
-id:
-  useCustom:
-  - foo
-  - bar
-```
+=== "YAML"
+    ```yaml
+    id:
+      useCustom:
+      - foo
+      - bar
+    ```
 
 -----
 
@@ -213,10 +219,11 @@ Group key: `metrics`
 | ***default*** | `false` |
 | ***supported*** | `true`, `false` |
 
-```YAML tab=
-metrics:
-  enabled: true
-```
+=== "YAML"
+    ```yaml
+    metrics:
+      enabled: true
+    ```
 
 -----
 
@@ -236,10 +243,11 @@ Group key: `settings`
 | ***default*** | `parallel` |
 | ***supported*** | `serial`, `parallel` |
 
-```YAML tab=
-settings:
-  mode: parallel
-```
+=== "YAML"
+    ```yaml
+    settings:
+      mode: parallel
+    ```
 
 #### Listen
 
@@ -264,11 +272,12 @@ Group key: `listen`
 | ***default*** | `false` |
 | ***supported*** | `true`, `false` |
 
-```YAML tab=
-settings:
-  listen:
-    disable: false
-```
+=== "YAML"
+    ```yaml
+    settings:
+      listen:
+        disable: false
+    ```
 
 #### Read
 
@@ -286,11 +295,12 @@ Group key: `read`
 | ***default*** | `false` |
 | ***supported*** | `true`, `false` |
 
-```YAML tab=
-settings:
-  read:
-    disable: false
-```
+=== "YAML"
+    ```yaml
+    settings:
+      read:
+        disable: false
+    ```
 
 ***Interval***
 
@@ -302,11 +312,12 @@ settings:
 | ***default*** | `1s` |
 | ***supported*** | [duration](https://golang.org/pkg/time/#example_Duration) strings |
 
-```YAML tab=
-settings:
-  read:
-    interval: 1s
-```
+=== "YAML"
+    ```yaml
+    settings:
+      read:
+        interval: 1s
+    ```
 
 ***Delay***
 
@@ -318,11 +329,12 @@ settings:
 | ***default*** | `0s` |
 | ***supported*** | [duration](https://golang.org/pkg/time/#example_Duration) strings |
 
-```YAML tab=
-settings:
-  read:
-    delay: 1s
-```
+=== "YAML"
+    ```yaml
+    settings:
+      read:
+        delay: 1s
+    ```
 
 ***QueueSize***
 
@@ -333,11 +345,12 @@ settings:
 | ***key*** | `queueSize` |
 | ***default*** | `128` |
 
-```YAML tab=
-settings:
-  read:
-    queueSize: 128
-```
+=== "YAML"
+    ```yaml
+    settings:
+      read:
+        queueSize: 128
+    ```
 
 #### Write 
 
@@ -355,11 +368,12 @@ Group key: `write`
 | ***default*** | `false` |
 | ***supported*** | `true`, `false` |
 
-```YAML tab=
-settings:
-  write:
-    disable: false
-```
+=== "YAML"
+    ```yaml
+    settings:
+      write:
+        disable: false
+    ```
 
 ***Interval***
 
@@ -371,11 +385,12 @@ settings:
 | ***default*** | `1s` |
 | ***supported*** | [duration](https://golang.org/pkg/time/#example_Duration) strings |
 
-```YAML tab=
-settings:
-  write:
-    interval: 1s
-```
+=== "YAML"
+    ```yaml
+    settings:
+      write:
+        interval: 1s
+    ```
 
 ***Delay***
 
@@ -387,11 +402,12 @@ settings:
 | ***default*** | `0s` |
 | ***supported*** | [duration](https://golang.org/pkg/time/#example_Duration) strings |
 
-```YAML tab=
-settings:
-  write:
-    delay: 1s
-```
+=== "YAML"
+    ```yaml
+    settings:
+      write:
+        delay: 1s
+    ```
 
 ***QueueSize***
 
@@ -402,11 +418,12 @@ settings:
 | ***key*** | `queueSize` |
 | ***default*** | `128` |
 
-```YAML tab=
-settings:
-  write:
-    queueSize: 128
-```
+=== "YAML"
+    ```yaml
+    settings:
+      write:
+        queueSize: 128
+    ```
 
 ***BatchSize***
 
@@ -417,11 +434,12 @@ settings:
 | ***key*** | `batchSize` |
 | ***default*** | `128` |
 
-```YAML tab=
-settings:
-  write:
-    batchSize: 128
-```
+=== "YAML"
+    ```yaml
+    settings:
+      write:
+        batchSize: 128
+    ```
 
 #### Transaction
 
@@ -439,11 +457,12 @@ Group key: `transaction`
 | ***default*** | `5m` |
 | ***supported*** | [duration](https://golang.org/pkg/time/#example_Duration) strings |
 
-```YAML tab=
-settings:
-  transaction:
-    ttl: 5m
-```
+=== "YAML"
+    ```yaml
+    settings:
+      transaction:
+        ttl: 5m
+    ```
 
 #### Limiter
 
@@ -460,11 +479,12 @@ Group key: `limiter`
 | ***key*** | `rate` |
 | ***default*** | `0` |
 
-```YAML tab=
-settings:
-  limiter:
-    rate: 0
-```
+=== "YAML"
+    ```yaml
+    settings:
+      limiter:
+        rate: 0
+    ```
 
 ***Burst***
 
@@ -475,11 +495,12 @@ settings:
 | ***key*** | `burst` |
 | ***default*** | `0` |
 
-```YAML tab=
-settings:
-  limiter:
-    burst: 0
-```
+=== "YAML"
+    ```yaml
+    settings:
+      limiter:
+        burst: 0
+    ```
 
 #### Cache
 
@@ -497,11 +518,12 @@ Group key: `cache`
 | ***default*** | `false` |
 | ***supported*** | `true`, `false` |
 
-```YAML tab=
-settings:
-  cache:
-    enabled: true
-```
+=== "YAML"
+    ```yaml
+    settings:
+      cache:
+        enabled: true
+    ```
 
 ***TTL***
 
@@ -513,11 +535,12 @@ settings:
 | ***default*** | `3m` |
 | ***supported*** | [duration](https://golang.org/pkg/time/#example_Duration) strings |
 
-```YAML tab=
-settings:
-  cache:
-    ttl: 3m
-```
+=== "YAML"
+    ```yaml
+    settings:
+      cache:
+        ttl: 3m
+    ```
 
 -----
 
@@ -537,10 +560,11 @@ Group key: `network`
 | ***default*** | `tcp` |
 | ***supported*** | `tcp`, `unix` |
 
-```YAML tab=
-network:
-  type: tcp
-```
+=== "YAML"
+    ```yaml
+    network:
+      type: tcp
+    ```
 
 #### Address
 
@@ -550,10 +574,11 @@ network:
 | ***type*** | string |
 | ***key*** | `address` |
 
-```YAML tab=
-network:
-  address: "0.0.0.0:5001"
-```
+=== "YAML"
+    ```yaml
+    network:
+      address: "0.0.0.0:5001"
+    ```
 
 #### TLS
 
@@ -569,11 +594,12 @@ Group key: `tls`
 | ***type*** | string |
 | ***key*** | `cert` |
 
-```YAML tab=
-network:
-  tls:
-    cert: /path/to/cert.crt
-```
+=== "YAML"
+    ```yaml
+    network:
+      tls:
+        cert: /path/to/cert.crt
+    ```
 
 ***Key***
 
@@ -583,11 +609,12 @@ network:
 | ***type*** | string |
 | ***key*** | `key` |
 
-```YAML tab=
-network:
-  tls:
-    key: /path/to/key.key
-```
+=== "YAML"
+    ```yaml
+    network:
+      tls:
+        key: /path/to/key.key
+    ```
 
 ***CA Certs***
 
@@ -597,12 +624,13 @@ network:
 | ***type*** | list[string] |
 | ***key*** | `caCerts` |
 
-```YAML tab=
-network:
-  tls:
-    caCerts: 
-    - /path/to/cacerts.ca
-```
+=== "YAML"
+    ```yaml
+    network:
+      tls:
+        caCerts: 
+        - /path/to/cacerts.ca
+    ```
 
 ***Skip Verify***
 
@@ -614,11 +642,12 @@ network:
 | ***default*** | `false` |
 | ***supported*** | `true`, `false` |
 
-```YAML tab=
-network:
-  tls:
-    skipVerify: true
-```
+=== "YAML"
+    ```yaml
+    network:
+      tls:
+        skipVerify: true
+    ```
 
 -----
 
@@ -637,12 +666,13 @@ Group key: `dynamicRegistration`
 | ***key*** | `config` |
 | ***default*** | `[]` |
 
-```YAML tab=
-dynamicRegistration:
-  config:
-  - foo: 1
-    bar: "baz"
-```
+=== "YAML"
+    ```yaml
+    dynamicRegistration:
+      config:
+      - foo: 1
+        bar: "baz"
+    ```
 
 -----
 
@@ -661,10 +691,11 @@ Group key: `health`
 | ***key*** | `healthFile` |
 | ***default*** | `/etc/synse/plugin/healthy` |
 
-```YAML tab=
-health:
-  healthFile: /etc/synse/plugin/healthy
-```
+=== "YAML"
+    ```yaml
+    health:
+      healthFile: /etc/synse/plugin/healthy
+    ```
 
 #### Update Interval
 
@@ -676,10 +707,11 @@ health:
 | ***default*** | `30s` |
 | ***supported*** | [duration](https://golang.org/pkg/time/#example_Duration) strings |
 
-```YAML tab=
-health:
-  updateInterval: 30s
-```
+=== "YAML"
+    ```yaml
+    health:
+      updateInterval: 30s
+    ```
 
 #### Checks
 
@@ -697,11 +729,12 @@ Group key: `checks`
 | ***default*** | `false` |
 | ***supported*** | `true`, `false` |
 
-```YAML tab=
-health:
-  checks:
-    disableDefaults: false
-```
+=== "YAML"
+    ```yaml
+    health:
+      checks:
+        disableDefaults: false
+    ```
 
 ## Example
 

--- a/docs/server/user/configuration.md
+++ b/docs/server/user/configuration.md
@@ -101,13 +101,15 @@ via environment variable.
 | ***default*** | `debug` |
 | ***supported*** | `debug`, `info`, `warning`, `error`, `critical` |
 
-```YAML tab=
-logging: info
-```
+=== "YAML"
+    ```yaml
+    logging: info
+    ```
 
-```Environment tab=
-SYNSE_LOGGING=info
-```
+=== "Environment"
+    ```.env
+    SYNSE_LOGGING=info
+    ```
 
 -----
 
@@ -122,9 +124,10 @@ SYNSE_LOGGING=info
 | ***default*** | `true` |
 | ***supported*** | `true`, `false` |
 
-```YAML tab=
-pretty_json: true
-```
+=== "YAML"
+    ```yaml
+    pretty_json: true
+    ```
 
 -----
 
@@ -142,16 +145,18 @@ Configuration options for registering plugins with the server instance.
 | ***env variable*** | `SYNSE_PLUGIN_TCP` |
 | ***default*** | -- |
 
-```YAML tab=
-plugin:
-  tcp:
-  - localhost:5001
-  - 192.1.53.2:5002
-```
+=== "YAML"
+    ```yaml
+    plugin:
+      tcp:
+      - localhost:5001
+      - 192.1.53.2:5002
+    ```
 
-```Environment tab=
-SYNSE_PLUGIN_TCP="localhost:5001,192.1.53.2:5002"
-```
+=== "Environment"
+    ```.env
+    SYNSE_PLUGIN_TCP="localhost:5001,192.1.53.2:5002"
+    ```
 
 #### Unix
 
@@ -163,15 +168,17 @@ SYNSE_PLUGIN_TCP="localhost:5001,192.1.53.2:5002"
 | ***env variable*** | `SYNSE_PLUGIN_UNIX` |
 | ***default*** | -- |
 
-```YAML tab=
-plugin:
-  unix:
-  - /tmp/example.sock
-```
+=== "YAML"
+    ```yaml
+    plugin:
+      unix:
+      - /tmp/example.sock
+    ```
 
-```Environment tab=
-SYNSE_PLUGIN_UNIX="/tmp/example.sock"
-```
+=== "Environment"
+    ```.env
+    SYNSE_PLUGIN_UNIX="/tmp/example.sock"
+    ```
 
 !!! note
     When registering a plugin via unix socket, Synse Server needs access to that socket. If the
@@ -200,16 +207,18 @@ Examples of using Kubernetes discovery can be found on the [Advanced Usage](adva
 | ***env variable*** | `SYNSE_PLUGIN_DISCOVER_KUBERNETES_NAMESPACE` |
 | ***default*** | 'default' |
 
-```YAML tab=
-plugin:
-  discover:
-    kubernetes:
-      namespace: default
-```
+=== "YAML"
+    ```yaml
+    plugin:
+      discover:
+        kubernetes:
+          namespace: default
+    ```
 
-```Environment tab=
-SYNSE_PLUGIN_DISCOVER_KUBERNETES_NAMESPACE=default
-```
+=== "Environment"
+    ```.env
+    SYNSE_PLUGIN_DISCOVER_KUBERNETES_NAMESPACE=default
+    ```
 
 ***Kubernetes Endpoint Labels***
 
@@ -221,20 +230,22 @@ SYNSE_PLUGIN_DISCOVER_KUBERNETES_NAMESPACE=default
 | ***env variable*** | `SYNSE_PLUGIN_DISCOVER_KUBERNETES_ENDPOINTS_LABELS_<KEY>` |
 | ***default*** | -- |
 
-```YAML tab=
-plugin:
-  discover:
-    kubernetes:
-      endpoints:
-        labels:
-          app: synse
-          foo: bar
-```
+=== "YAML"
+    ```yaml
+    plugin:
+      discover:
+        kubernetes:
+          endpoints:
+            labels:
+              app: synse
+              foo: bar
+    ```
 
-```Environment tab=
-SYNSE_PLUGIN_DISCOVER_KUBERNETES_ENDPOINTS_LABELS_APP=synse
-SYNSE_PLUGIN_DISCOVER_KUBERNETES_ENDPOINTS_LABELS_FOO=bar
-```
+=== "Environment"
+    ```.env
+    SYNSE_PLUGIN_DISCOVER_KUBERNETES_ENDPOINTS_LABELS_APP=synse
+    SYNSE_PLUGIN_DISCOVER_KUBERNETES_ENDPOINTS_LABELS_FOO=bar
+    ```
 
 -----
 
@@ -257,11 +268,12 @@ Configuration options for Synse Server caches. There are two caches in the serve
 | ***env variable*** | -- |
 | ***default*** | 180 |
 
-```YAML tab=
-cache:
-  device:
-    rebuild_every: 180  # three minutes
-```
+=== "YAML"
+    ```yaml
+    cache:
+      device:
+        rebuild_every: 180  # three minutes
+    ```
 
 #### Plugin
 
@@ -275,11 +287,12 @@ cache:
 | ***env variable*** | -- |
 | ***default*** | 120 |
 
-```YAML tab=
-cache:
-  plugin:
-    refresh_every: 120  # two minutes
-```
+=== "YAML"
+    ```yaml
+    cache:
+      plugin:
+        refresh_every: 120  # two minutes
+    ```
 
 #### Transaction
 
@@ -293,11 +306,12 @@ cache:
 | ***env variable*** | -- |
 | ***default*** | 300 |
 
-```YAML tab=
-cache:
-  transaction:
-    ttl: 300  # five minutes
-```
+=== "YAML"
+    ```yaml
+    cache:
+      transaction:
+        ttl: 300  # five minutes
+    ```
 
 -----
 
@@ -315,10 +329,11 @@ Configuration options for requests made from the server to plugins via the inter
 | ***env variable*** | -- |
 | ***default*** | 3 |
 
-```YAML tab=
-grpc:
-  timeout: 3
-```
+=== "YAML"
+    ```yaml
+    grpc:
+      timeout: 3
+    ```
 
 #### TLS
 
@@ -334,15 +349,17 @@ TLS configurations for the internal gRPC client used to communicate with plugins
 | ***env variable*** | `SYNSE_GRPC_TLS_CERT` |
 | ***default*** | -- |
 
-```YAML tab=
-grpc:
-  tls:
-    cert: /path/to/cert.pem
-```
+=== "YAML"
+    ```yaml
+    grpc:
+      tls:
+        cert: /path/to/cert.pem
+    ```
 
-```Environment tab=
-SYNSE_GRPC_TLS_CERT="/path/to/cert.pem"
-```
+=== "Environment"
+    ```.env
+    SYNSE_GRPC_TLS_CERT="/path/to/cert.pem"
+    ```
 
 -----
 
@@ -360,14 +377,16 @@ Configuration options for securing the server's HTTP/WebSocket APIs.
 | ***env variable*** | `SYNSE_SSL_CERT` |
 | ***default*** | -- |
 
-```YAML tab=
-ssl:
-  cert: /path/to/cert.pem
-```
+=== "YAML"
+    ```yaml
+    ssl:
+      cert: /path/to/cert.pem
+    ```
 
-```Environment tab=
-SYNSE_SSL_CERT="/path/to/cert.pem"
-```
+=== "Environment"
+    ```.env
+    SYNSE_SSL_CERT="/path/to/cert.pem"
+    ```
 
 ***Key***
 
@@ -379,14 +398,16 @@ SYNSE_SSL_CERT="/path/to/cert.pem"
 | ***env variable*** | `SYNSE_SSL_KEY` |
 | ***default*** | -- |
 
-```YAML tab=
-ssl:
-  key: /path/to/key.key
-```
+=== "YAML"
+    ```yaml
+    ssl:
+      key: /path/to/key.key
+    ```
 
-```Environment tab=
-SYNSE_SSL_KEY="/path/to/key.key"
-```
+=== "Environment"
+    ```.env
+    SYNSE_SSL_KEY="/path/to/key.key"
+    ```
 
 -----
 
@@ -405,14 +426,16 @@ Configuration options for exposing application metrics via Prometheus exporter.
 | ***default*** | `false` |
 | ***supported*** | `true`, `false` |
 
-```YAML tab=
-metrics:
-  enabled: true
-```
+=== "YAML"
+    ```yaml
+    metrics:
+      enabled: true
+    ```
 
-```Environment tab=
-SYNSE_METRICS_ENABLED=true
-```
+=== "Environment"
+    ```.env
+    SYNSE_METRICS_ENABLED=true
+    ```
 
 -----
 


### PR DESCRIPTION
…ate outdated superfences formatting


this was a two-parter
- the update to poetry didn't update the RTD config properly
- an update to a dependency meant that the tabbed block formatting being used was outdated/no longer supported

fixes #42 